### PR TITLE
correct link to vuemc.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ### Documentation
 
-Documentation is available at **[http://vuemc.io]()**
+Documentation is available at **[http://vuemc.io](http://vuemc.io)**
 
 ### Development
 


### PR DESCRIPTION
The smallest possible patch ;-)
The current link is incorrectly markdown formatted and led to https://github.com/FiguredLimited/vue-mc/blob/master