### PR TITLE
Make sure all of the used symbols are actually imported

### DIFF
--- a/src/HTTP/ProxyResponse.js
+++ b/src/HTTP/ProxyResponse.js
@@ -1,3 +1,5 @@
+import _ 	    from 'lodash'
+
 class ProxyResponse {
 
     constructor(status, data = {}, headers = {}) {

--- a/src/HTTP/Request.js
+++ b/src/HTTP/Request.js
@@ -1,3 +1,5 @@
+import axios        from 'axios'
+
 import Response     from './Response.js'
 import RequestError from '../Errors/RequestError.js'
 

--- a/src/HTTP/Response.js
+++ b/src/HTTP/Response.js
@@ -1,3 +1,5 @@
+import _ 	    from 'lodash'
+
 class Response {
 
     constructor(response) {

--- a/src/Structures/Base.js
+++ b/src/Structures/Base.js
@@ -1,8 +1,8 @@
-import _ 	    from 'lodash'
+import _ 	            from 'lodash'
+import Vue              from "vue";
 
 import Request          from '../HTTP/Request.js'
-import ValidationError  from '../Errors/ValidationError.js'
-import {autobind }       from '../utils.js';
+import {autobind }      from '../utils.js';
 
 /**
  * Base class for all things common between Model and Collection.

--- a/src/Structures/Base.js
+++ b/src/Structures/Base.js
@@ -1,3 +1,5 @@
+import _ 	    from 'lodash'
+
 import Request          from '../HTTP/Request.js'
 import ValidationError  from '../Errors/ValidationError.js'
 import {autobind }       from '../utils.js';

--- a/src/Structures/Collection.js
+++ b/src/Structures/Collection.js
@@ -1,4 +1,5 @@
-import _ 	    from 'lodash'
+import _ 	            from 'lodash'
+import Vue              from 'vue'
 
 import Base             from './Base.js'
 import Model            from './Model.js'

--- a/src/Structures/Collection.js
+++ b/src/Structures/Collection.js
@@ -1,3 +1,5 @@
+import _ 	    from 'lodash'
+
 import Base             from './Base.js'
 import Model            from './Model.js'
 import ResponseError    from '../Errors/ResponseError.js'

--- a/src/Structures/Model.js
+++ b/src/Structures/Model.js
@@ -1,4 +1,5 @@
-import _ 	    from 'lodash'
+import _ 	            from 'lodash'
+import Vue              from 'vue'
 
 import Base             from './Base.js'
 import Collection       from './Collection.js'

--- a/src/Structures/Model.js
+++ b/src/Structures/Model.js
@@ -1,3 +1,5 @@
+import _ 	    from 'lodash'
+
 import Base             from './Base.js'
 import Collection       from './Collection.js'
 import ResponseError    from '../Errors/ResponseError.js'

--- a/src/Validation/index.js
+++ b/src/Validation/index.js
@@ -1,3 +1,5 @@
+import _ 	    from 'lodash'
+
 import { en_us }        from './locale.js'
 import isAlpha          from 'validator/lib/isAlpha'
 import isAlphanumeric   from 'validator/lib/isAlphanumeric'

--- a/src/Validation/index.js
+++ b/src/Validation/index.js
@@ -1,4 +1,6 @@
-import _ 	    from 'lodash'
+/* global window global */
+import moment           from 'moment'
+import _ 	            from 'lodash'
 
 import { en_us }        from './locale.js'
 import isAlpha          from 'validator/lib/isAlpha'

--- a/test/Structures/Collection.spec.js
+++ b/test/Structures/Collection.spec.js
@@ -1,3 +1,5 @@
+import _ 	    from 'lodash'
+
 import moxios from 'moxios'
 import {assert, expect} from 'chai'
 import {Model, Collection} from '../../src/index.js'

--- a/test/Structures/Model.spec.js
+++ b/test/Structures/Model.spec.js
@@ -1,3 +1,5 @@
+import _ 	    from 'lodash'
+
 import moxios from 'moxios'
 import {assert, expect} from 'chai'
 import {Model, Collection} from '../../src/index.js'


### PR DESCRIPTION
Use es6 to import the required packages, this way we don't depend on global symbols.

Closes #4 