### PR TITLE
Remove global window registration of Collection and Model

### DIFF
--- a/docs/_includes/basic-usage.md
+++ b/docs/_includes/basic-usage.md
@@ -3,18 +3,10 @@ Basic Usage {#basic-usage}
 
 You should extend the base classes to create appropriate models and collections for your data. The example we'll use is a basic **task list**, consisting of a list (`Collection`) of tasks (`Model`).
 
-{% highlight js %}
-import {Model, Collection} from 'vue-mc'
-
-// Set the on the global on the window so that you don't have to import
-// the base classes in every model and collection class or component.
-window.Model = Model;
-window.Collection = Collection;
-{% endhighlight %}
-
 #### Extending the base classes  {#basic-usage-extend}
 
 {% highlight js %}
+import {Model, Collection} from 'vue-mc'
 
 /**
  * Task model


### PR DESCRIPTION
Remove the documentation which suggests registering `Collection` and `Model` as `window` globals.

Closes #5 