### PR TITLE
Babel7

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,12 +1,17 @@
 {
   "presets": [
-    ["env", {
+    ["@babel/preset-env", {
       "targets": {
-        "node": "current"
+        "browsers": [
+        ">0.25%",
+        "not ie 10",
+        "not op_mini all"
+        ]
       }
     }]
   ],
   "plugins": [
-      "istanbul", "transform-decorators-legacy"
+      "istanbul", 
+      ["@babel/plugin-proposal-decorators", { "legacy": true }]
   ]
 }

--- a/package.json
+++ b/package.json
@@ -34,49 +34,45 @@
         "url": "https://github.com/rtheunissen"
     },
     "dependencies": {
-        "axios": "^0.16",
-        "lodash": "^4.17",
-        "moment": "^2.18.1",
-        "validator": "^8.1.0",
-        "vue": "^2.2"
+        "axios": "0.18",
+        "lodash": "4.17",
+        "moment": "2.22.2",
+        "validator": "10.4.0"
     },
     "devDependencies": {
-        "array-permutation": "^0.2.0",
-        "axios": "^0.16",
-        "babel-cli": "^6.26.0",
-        "babel-core": "^6.26.0",
-        "babel-plugin-autobind-class-methods": "^5.0.1",
-        "babel-plugin-external-helpers": "^6.22.0",
-        "babel-plugin-istanbul": "^4.1.4",
-        "babel-plugin-transform-decorators-legacy": "^1.3.4",
-        "babel-preset-env": "^1.6.0",
-        "babel-preset-es2015": "^6.24.1",
-        "babel-register": "^6.26.0",
-        "chai": "^4.1.1",
-        "eslint": "^4.7.2",
-        "lodash": "^4.17",
-        "mocha": "^3.5.0",
-        "moment": "^2.18.1",
-        "moxios": "^0.4.0",
-        "nyc": "^11.1.0",
-        "rollup": "^0.50.0",
-        "rollup-plugin-babel": "^3.0.2",
-        "rollup-plugin-buble": "^0.15.0",
-        "rollup-plugin-commonjs": "^8.0.2",
-        "rollup-plugin-json": "^2.3.0",
-        "rollup-plugin-node-resolve": "^3.0.0",
-        "vue": "^2.2"
+        "@babel/core": "7.0.0-beta.51",
+        "@babel/plugin-external-helpers": "7.0.0-beta.51",
+        "@babel/plugin-proposal-decorators": "7.0.0-beta.51",
+        "@babel/preset-env": "7.0.0-beta.51",
+        "@babel/register": "7.0.0-beta.51",
+        "array-permutation": "0.2.0",
+        "axios": "0.18",
+        "babel-plugin-istanbul": "4.1.6",
+        "chai": "4.1.2",
+        "eslint": "5.0.0",
+        "lodash": "4.17",
+        "mocha": "5.2.0",
+        "moment": "2.22.2",
+        "moxios": "0.4.0",
+        "nyc": "12.0.2",
+        "rollup": "0.61.2",
+        "rollup-plugin-babel": "3.0.5",
+        "rollup-plugin-buble": "0.19.2",
+        "rollup-plugin-commonjs": "9.1.3",
+        "rollup-plugin-json": "3.0.0",
+        "rollup-plugin-node-resolve": "3.3.0",
+        "vue": "2.5"
     },
     "scripts": {
         "build": "rollup -c",
         "lint": "eslint ./src/",
         "test": "nyc mocha ./test",
         "docs": "cd docs && jekyll serve",
-        "prepublishOnly": "yarn test && yarn build"
+        "prepublishOnly": "npm run test && npm run build"
     },
     "nyc": {
         "require": [
-            "babel-register"
+            "@babel/register"
         ],
         "reporter": [
             "lcov",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,8 +16,16 @@ const BASE = {
 		commonjs(),
 		babel({
 			babelrc: false,
-			plugins: ["external-helpers"],
-			presets: [["es2015", {modules: false}]],
+			plugins: ['@babel/plugin-external-helpers'],
+			presets: [['@babel/preset-env', {
+				targets: {
+				  browsers: [
+					'>0.25%',
+					'not ie 10',
+					'not op_mini all'
+				  ]
+				}
+			}]],
 			exclude: [
 				'node_modules/**'
 			]


### PR DESCRIPTION
Migrate library to babel v7 compatibility.

With that, I remove unused libraries and force specific version.
I change the `preset` env presets to set navigators compatibility : not specific node version