### PR TITLE
Fix Model.clone()

### DIFF
--- a/src/Structures/Model.js
+++ b/src/Structures/Model.js
@@ -149,7 +149,7 @@ class Model extends Base {
         let clone = new (this.constructor)();
 
         // Make sure that the clone belongs to the same collections.
-        clone.registerCollection(this._collections);
+        clone.registerCollection(this.collections);
 
         // Make sure that the clone has the same existing options.
         clone.setOptions(this.getOptions());

--- a/test/Structures/Model.spec.js
+++ b/test/Structures/Model.spec.js
@@ -2895,4 +2895,16 @@ describe('Model', () => {
             let m = new Model();
         })
     })
+
+    describe('clone', () => {
+        it('should return a clone of the model', () => {
+            const m = new Model({data: 1});
+            const clone = m.clone();
+
+            expect(clone.attributes).to.deep.equal(m.attributes);
+            expect(clone.getOptions()).to.deep.equal(m.getOptions());
+            expect(clone.collections).to.deep.equal(m.collections);
+            expect(clone._uid).to.not.equal(m._uid);
+        })
+    })
 })


### PR DESCRIPTION
[`Model.clone()`](https://github.com/FiguredLimited/vue-mc/blob/c7967f519fb9400e78d1c66bd72f4704139e5eb3/src/Structures/Model.js#L134-L161) calls [`Model.registerCollection()`](https://github.com/FiguredLimited/vue-mc/blob/c7967f519fb9400e78d1c66bd72f4704139e5eb3/src/Structures/Model.js#L277-L296) and passes `this._collections`, which is an object. However, `Model.registerCollection()` expects either a single collection or an array, and passing an object causes it to throw an error that `'Collection is not valid'`.

This fixes `Model.clone()` to pass [`this.collections`](https://github.com/FiguredLimited/vue-mc/blob/c7967f519fb9400e78d1c66bd72f4704139e5eb3/src/Structures/Model.js#L85-L90) instead, which uses `_.values` to extract an array of collections.