### PR TITLE
Change Model.getSaveData() to always include the identifier if patching

### DIFF
--- a/src/Structures/Model.js
+++ b/src/Structures/Model.js
@@ -822,10 +822,9 @@ class Model extends Base {
      * @returns {Object} The data to send to the server when saving this model.
      */
     getSaveData() {
-
         // Only use changed attributes if patching.
         if (this.isExisting() && this.shouldPatch()) {
-            return _.pick(this._attributes, this.changed());
+            return _.pick(this._attributes, this.changed(), this.getOption('identifier'));
         }
 
         return this._attributes;

--- a/test/Structures/Model.spec.js
+++ b/test/Structures/Model.spec.js
@@ -3046,4 +3046,18 @@ describe('Model', () => {
             expect(clone._uid).to.not.equal(m._uid);
         })
     })
+
+    describe.only('getSaveData', () => {
+        it('should always include the identifier if the model is being patched', () => {
+            const m = new Model({id: 1, data: 2});
+            m.data = 3;
+            m.setOption('patch', true);
+            const saveData = m.getSaveData();
+
+            expect(saveData).to.deep.equal({
+                id: 1,
+                data: 3,
+            });
+        })
+    })
 })


### PR DESCRIPTION
Fixes #74.

Replaces #78.