### PR TITLE
Fix a missing `this`

### DIFF
--- a/src/Structures/Base.js
+++ b/src/Structures/Base.js
@@ -584,7 +584,7 @@ class Base {
         let data = _.defaultTo(options.data, this.getSaveData());
 
         let config = () => _.assign(options, {
-            data: convertObjectToFormData(data),
+            data: this.convertObjectToFormData(data),
         });
 
         return this.save(config);


### PR DESCRIPTION
`Base.upload()` calls `convertObjectToFormData()`, but there's no such function; only a method on `Base`.