### PR TITLE
Export Request, Response and RequestError to enable custom Axios instance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,10 @@
  *
  * @author Rudi Theunissen <rudi.theunissen@figured.com>
  */
-import Model      from './Structures/Model.js'
-import Collection from './Structures/Collection.js'
+import Model        from './Structures/Model.js'
+import Collection   from './Structures/Collection.js'
+import Request      from './HTTP/Request.js'
+import Response     from './HTTP/Response.js'
+import RequestError from './Errors/RequestError.js'
 
-export { Model, Collection }
+export { Model, Collection, Request, Response, RequestError }


### PR DESCRIPTION
By exposing `Request`, `Response` and `RequestError`, we can create requests using our own Axios instance. 

Example:

```
import { Request, Response, RequestError } from 'vue-mc'
import customAxiosInstance from './customAxiosInstance'

export default class CustomRequest extends Request{

  constructor() {
      super();
  }

  /**
   * @returns {Promise}
   */
  send() {
    return customAxiosInstance.request(this.config).then((response) => {
      return new Response(response);
    }).catch((error) => {
      throw new RequestError(error, new Response(error.response));
    });
  }

}
```

It can be used inside `Model` or `Collection` like this:

```
getRequest (config) {
    return new CustomRequest(config);
}
```

Ran into this issue while working on an app that had to use Axios interceptors.