### PR TITLE
update package json to use the latest minor version of vue

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "date-fns": "^2.0.0-alpha.25",
         "lodash": "^4.17.11",
         "validator": "^10.9.0",
-        "vue": "2.5.17"
+        "vue": "^2.5.17"
     },
     "devDependencies": {
         "@babel/core": "^7.1.6",


### PR DESCRIPTION
Currently the version of vue that vue-mc uses is locked at 2.5.17, which causes multiple versions of vue to be loaded in applications using the latest version of vue. This pull request adds `^` to vue in package.json so that it will match the latest minor version and not cause multiple instances of vue to be installed.