### PR TITLE
Fix incompatible type of methods in ModelOptions

### DIFF
--- a/src/Structures/Model.ts
+++ b/src/Structures/Model.ts
@@ -28,7 +28,7 @@ import once from 'lodash/once';
 import pick from 'lodash/pick';
 import values from 'lodash/values';
 
-import Base, {HttpMethods, Options, RequestOperation} from './Base';
+import Base, {HttpMethods, Options, RequestOperation, RequestType} from './Base';
 import Collection from './Collection';
 import ResponseError from '../Errors/ResponseError';
 import Response from "../HTTP/Response";
@@ -1214,10 +1214,7 @@ export default Model;
 interface ModelOptions extends Options {
     [key: string]: any;
 
-    methods?: {
-        [key: string]: HttpMethods;
-
-    };
+    methods?: Partial<Record<RequestType, HttpMethods>>;
 
     /**
      * The attribute that should be used to uniquely identify this model.


### PR DESCRIPTION
The following type error occured when compiling my project:
```
258:9 Type 'Options & { identifier: string; overwriteIdentifier: boolean; patch: boolean; saveUncha
nged: boolean; useFirstErrorOnly: boolean; validateOnChange: boolean; validateRecursively: boolean;
 mutateOnChange: boolean; mutateBeforeSync: boolean; mutateBeforeSave: boolean; }' is not assignabl
e to type 'ModelOptions'.
  Types of property 'methods' are incompatible.
    Type 'Partial<Record<string, string>> | undefined' is not assignable to type '{ [key: string]:
string; } | undefined'.
      Type 'Partial<Record<string, string>>' is not assignable to type '{ [key: string]: string; }'
.
        Index signatures are incompatible.
          Type 'string | undefined' is not assignable to type 'string'.
            Type 'undefined' is not assignable to type 'string'.
    256 |      */
    257 |     getDefaultOptions(): ModelOptions {
  > 258 |         return merge({}, super.getDefaultOptions(), {
        |         ^
    259 |
    260 |             // The attribute that should be used to uniquely identify this model.
    261 |             identifier: 'id',
Version: typescript 3.9.6
```

It looks like the [`ModelOptions` in `structures/Model.ts`](https://github.com/FiguredLimited/vue-mc/blob/master/src/Structures/Model.ts#L1217) has a different definition for `methods` than [`Options` in `structures/Base.ts`](https://github.com/FiguredLimited/vue-mc/blob/master/src/Structures/Base.ts#L697).